### PR TITLE
Fix bash highlighting

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -823,7 +823,7 @@ func main() {
 
 ### HMAC Calculation (Bash Script)
 
-```bashscript
+```bash
 #!/bin/bash
 
 function hash_hmac {


### PR DESCRIPTION
The code example should be tagged as `bash` instead of `bashscript` in order to get the highlighting.