### PR TITLE
Add Python language highlighter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,7 @@
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-java.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-go.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-python.min.js"></script>
     <script>
       var num = 0;
       mermaid.initialize({


### PR DESCRIPTION
We have Python code example but no syntax highlighting for that language, so let's add one.