### PR TITLE
Fix C# title

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -868,7 +868,7 @@ echo "\n\nRequest ID: {$response->getHeader('cof-request-id')[0]}\n\n";
 ```
 
 
-### Calculating HMAC (C#)
+### HMAC calculation (C#)
 
 ```cs
 // HMACCalculation.cs


### PR DESCRIPTION
The title of the example code was formatted differently than others.