### PR TITLE
Fix parameter map example quotes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -399,7 +399,7 @@ const applePayParameters = response.customProviders.applepay.parameters;
 
 const responseToApplePayHtml = (response) =>
   `<div id="apple-pay-button">
-    ${applePayParameters.map((param) => `<input type='hidden' name='${param.name}' value='${param.value}' />`)}
+    ${applePayParameters.map((param) => `<input type="hidden" name="${param.name}" value="${param.value}" />`)}
   </div>`;
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1377,15 +1377,15 @@ fn main() {
 Dummy form rendering from the example [response](#response):
 
 ```javascript
-const parameterToInput = (param) => `<input type='hidden' name='${param.name}' value='${param.value}' />`;
+const parameterToInput = (param) => `<input type="hidden" name="${param.name}" value="${param.value}" />`;
 
 const responseToHtml = (response) =>
   response.providers
     .map(
       (provider) =>
-        `<form method='POST' action=${provider.url}>
+        `<form method="POST" action="${provider.url}">
             ${provider.parameters.map(parameterToInput)}
-            <button><img src='${provider.svg}' /></button>
+            <button><img src="${provider.svg}" /></button>
         </form>`
     )
     .join('\n');


### PR DESCRIPTION
This changes the single quotes in `parameterToInput` and `responseToHtml` Javascript examples into double quotes to fix a bug where one of the values may contain a single quote cutting off the rest of the value which results in signature mismatches. (e.g. merchant marketing name may be `Vponline's Store` which ends up as `Vponline` on the mapped form).