### PR TITLE
includeItems parameter added to payment report API documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -781,6 +781,7 @@ A Shop-in-Shop aggregate merchant can also fetch its submerchant's payment repor
 | limit         | integer  | <center></center>  | `50000`   | Limit the amount of payments included in the report. Maximum 50000.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | reportFields  | string[] | <center></center>  | all       | Limit the fields that will be included in the report. Leaving this empty will include all fields. Possible values: `entryDate`, `created`, `amount`, `status`, `firstname`, `familyname`, `description`, `reference`, `paymentMethod`, `stamp`, `address`, `postcode`, `postoffice`, `country`, `checkoutReference`, `archiveNumber`, `payerName`, `settlementId`, `settlementDate`, `settlementReference`, `originalTradeReference`, `vatPercentage`, `vatAmount`, `paymentMethodFee`, `paymentMethodCommission`, `shopInShopCommission`, `shopInShopCommissionVatPercentage`, `shopInShopCommissionVatAmount`, `companyName`, `vatId` and `refunditems` |
 | submerchant   | integer  | <center></center>  |           | Get submerchant's payment report (aggregate only)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| includeItems  | boolean  | <center></center>  | false     | Include trade items in generated report. Only applicable when requestType is set to `json`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 #### Response
 
@@ -829,6 +830,11 @@ A Shop-in-Shop aggregate merchant can also fetch its submerchant's payment repor
       {
         stamp: 'stamp2', amount: -5
       },
+    ],
+    tradeitems: [
+      {
+        stamp: 'stamp1', amount: 2555, description: 'item',  vat: 24, code: 'ABC', quantity: 1
+      }
     ]
   }
 ]

--- a/docs/paytrail-api.yaml
+++ b/docs/paytrail-api.yaml
@@ -1999,12 +1999,17 @@ components:
                 shopInShopCommissionVatPercentage,
                 shopInShopCommissionVatAmount,
                 refunditems,
+                tradeitems
 
               ]
         submerchant:
           type: integer
           example: 695874
           description: Get submerchant's payment report
+        includeItems:
+          type: boolean
+          example: true
+          description: Include trade items in created payment report
 
     PaymentRequestResponse:
       type: object


### PR DESCRIPTION
Included info about optional `includeItems` parameter in payment report API.
