### PR TITLE
Removed link to old Checkout Finland API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,6 @@ OpenAPI 3 specification for the API is also [available for download](paytrail-ap
 
 ?> If you have any feedback regarding how we could improve the documentation, [please file an issue on Github](https://github.com/paytrail/api-documentation/issues). You can also ask for support by opening an issue on GitHub. Thank you!
 
-?> [Checkout Finland API reference](https://checkoutfinland.github.io/psp-api/#/) is available separately.
-
 ## API endpoint
 
 API endpoint is `services.paytrail.com`.


### PR DESCRIPTION
This removes the text and link to the old Checkout Finland API from the Home -page