### PR TITLE
Removing old E2, updating text

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -24,7 +24,6 @@ The main differences are:
   - `cof-plugin-version` is now `platform-name`
 - One previously required field has been made optional:
   - `deliveryDate`
-- Email refund responses now have status `new`. Status `ok` callback will be sent when the actual refund has been completed.
 
 ## Paytrail Payment API endpoints
 


### PR DESCRIPTION
Removing information of E2 interface since it hasn’t existed in years.
Changing text so that it describes the current API as current instead of new, and the Checkout API is described as old.
