### PR TITLE
Escaping to examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1380,7 +1380,9 @@ fn main() {
 
 ### Payment provider form rendering
 
-Dummy form rendering from the example [response](#response):
+Dummy form rendering from the example [response](#response)
+
+Developers should ensure that any API response data is properly escaped before rendering it into HTML.
 
 ```javascript
 const parameterToInput = (param) => `<input type="hidden" name="${param.name}" value="${param.value}" />`;


### PR DESCRIPTION
Adding text "Developers should ensure that any API response data is properly escaped before rendering it into HTML" below Payment provider form rendering.
